### PR TITLE
Fix undefined method Illuminate\Http\Response::getTargetUrl

### DIFF
--- a/src/ExceptionHandlerTrait.php
+++ b/src/ExceptionHandlerTrait.php
@@ -13,6 +13,7 @@ namespace GrahamCampbell\Exceptions;
 
 use Exception;
 use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/ExceptionHandlerTrait.php
+++ b/src/ExceptionHandlerTrait.php
@@ -81,6 +81,10 @@ trait ExceptionHandlerTrait
 
         $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
 
+        if ($e instanceof ValidationException) {
+            return $this->convertValidationExceptionToResponse($e, $request);
+        }
+
         if (!$response instanceof Response) {
             try {
                 $response = $this->getResponse($request, $e, $transformed);


### PR DESCRIPTION
@GrahamCampbell 

I think a found the cause behind this issue: https://github.com/GrahamCampbell/Laravel-Exceptions/issues/57

Seems like the problem is that the render method of this package always returns an Illuminate\Http\Response.

When running a test that throws a `ValidationException` laravel calls the `followRedirects` method, checks if the response is a redirect (which it is) and then tries to call `getTargetUrl` on the response.

Since `Illuminate\Http\Response` doesn't have a `getTargetUrl` method it fails.

This commit tries to fix this by checking if the exception was indeed a `ValidationException` and calls the appropriate method `convertValidationExceptionToResponse` to return a `RedirectResponse`.
