### PR TITLE
QueryTransformer added

### DIFF
--- a/config/exceptions.php
+++ b/config/exceptions.php
@@ -29,6 +29,7 @@ return [
         'GrahamCampbell\Exceptions\Transformers\AuthTransformer',
         'GrahamCampbell\Exceptions\Transformers\CsrfTransformer',
         'GrahamCampbell\Exceptions\Transformers\ModelTransformer',
+        'GrahamCampbell\Exceptions\Transformers\QueryTransformer',
     ],
 
     /*

--- a/src/Transformers/QueryTransformer.php
+++ b/src/Transformers/QueryTransformer.php
@@ -37,7 +37,7 @@ class QueryTransformer implements TransformerInterface
                 $exception = new ConflictHttpException($exception->getMessage(), $exception, $exception->getCode());
             }
             else {
-                $exception = new BadRequestHttpException($exception->getMessage(), $exception, $exception->getCode());
+                $exception = new BadRequestHttpException($exception->getMessage(), $exception); // getCode can have letters, e.g. 42S22 so cannot go in.
             }
         }
         return $exception;

--- a/src/Transformers/QueryTransformer.php
+++ b/src/Transformers/QueryTransformer.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of Laravel Exceptions.
+ *
+ * (c) Graham Campbell <graham@alt-three.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace GrahamCampbell\Exceptions\Transformers;
+
+use Exception;
+use Illuminate\Database\QueryException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+/**
+ * This is the query transformer class.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ */
+class QueryTransformer implements TransformerInterface
+{
+    /**
+     * Transform the provided exception.
+     *
+     * @param \Exception $exception
+     *
+     * @return \Exception
+     */
+    public function transform(Exception $exception)
+    {
+        if ($exception instanceof QueryException) {
+            if($exception->getCode() == 23000){ // Integrity constraint violation
+                $exception = new ConflictHttpException($exception->getMessage(), $exception, $exception->getCode());
+            }
+            else {
+                $exception = new BadRequestHttpException($exception->getMessage(), $exception, $exception->getCode());
+            }
+        }
+        return $exception;
+    }
+}


### PR DESCRIPTION
e.g. for a QueryException with code 23000:

```
{
  "errors": [
    {
      "id": "ad33d363-787f-4cdb-a99d-2e043d7e3152",
      "status": "409",
      "title": "Conflict",
      "detail": "SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'name' cannot be null (SQL: update `venues` set `updated_at` = 2016-09-01 21:01:52, `name` =  where `id` = 1)"
    }
  ]
}
```

And for an unknown column exception:

```
{
  "errors": [
    {
      "id": "45853536-13df-4b55-92e4-bf1faa31c6a0",
      "status": "400",
      "title": "Bad Request",
      "detail": "SQLSTATE[42S22]: Column not found: 1054 Unknown column 'test' in 'field list' (SQL: select `test` from `venues` where `venues`.`id` = 1 limit 1)"
    }
  ]
}
```

If you don't like seeing the sql in the detail message I can hide that and show it only if config(app.debug) is on.
