### PR TITLE
[WIP] Fix AuthenticationException and ValidationException

### DIFF
--- a/src/ExceptionHandlerTrait.php
+++ b/src/ExceptionHandlerTrait.php
@@ -12,8 +12,10 @@
 namespace GrahamCampbell\Exceptions;
 
 use Exception;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirectResponse;
@@ -83,7 +85,11 @@ trait ExceptionHandlerTrait
 
         $response = method_exists($e, 'getResponse') ? $e->getResponse() : null;
 
-        if (!$response instanceof Response) {
+        if ($e instanceof AuthenticationException) {
+            return $this->unauthenticated($request, $e);
+        } elseif ($e instanceof ValidationException) {
+            return $this->convertValidationExceptionToResponse($e, $request);
+        } elseif (!$response instanceof Response) {
             try {
                 $response = $this->getResponse($request, $e, $transformed);
             } catch (Exception $e) {


### PR DESCRIPTION
Hi @GrahamCampbell 

There is a Problem when use laravel-exceptions with Laravel 5.3.

The `unauthorized` method of `Exceptions\Handler.php` is never called. So there is only a Error `Unauthorized` Message. 

For my current Laravel 5.3 app the commited fix seems working. I can't test it correctly since there are a lot tests failing.

How could we fix this for all versions? 

Hope this helps in any way.
