### PR TITLE
Handler requires full container in constructor

### DIFF
--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -57,6 +57,8 @@ class ExceptionHandler extends Handler
         $this->config = $container->config->get('exceptions', []);
         $this->container = $container;
 
-        parent::__construct($container->make(LoggerInterface::class));
+        $container->make(LoggerInterface::class);
+
+        parent::__construct($container);
     }
 }


### PR DESCRIPTION
The extends `Handler` class requires the full container now. This breaks the tests and projects in Laravel 5.3.

See: [Handler.php](https://github.com/laravel/framework/blob/5.3/src/Illuminate/Foundation/Exceptions/Handler.php#L46)

So the tests fail for PHP 5.5, but as far as I know it's not supported any more by newer versions of Laravel. Let me know what you think of this
