### PR TITLE
Duplicate header problem is solved.

### DIFF
--- a/src/Displayers/DebugDisplayer.php
+++ b/src/Displayers/DebugDisplayer.php
@@ -37,7 +37,7 @@ class DebugDisplayer implements DisplayerInterface
     {
         $content = $this->whoops()->handleException($exception);
 
-        return new Response($content, $code, array_merge($headers, ['Content-Type' => 'text/html']));
+        return new Response($content, $code, $headers);
     }
 
     /**

--- a/src/Displayers/DebugDisplayer.php
+++ b/src/Displayers/DebugDisplayer.php
@@ -36,8 +36,9 @@ class DebugDisplayer implements DisplayerInterface
     public function display(Exception $exception, $id, $code, array $headers)
     {
         $content = $this->whoops()->handleException($exception);
+        header_remove('Content-Type');
 
-        return new Response($content, $code, $headers);
+        return new Response($content, $code, array_merge($headers, ['Content-Type' => 'text/html']));
     }
 
     /**


### PR DESCRIPTION
Duplicate headers are causing 500 Internal Server Error on debug mode with Whoops.

Because Whoops has already sent content-type header at vendor/filp/whoops/src/Whoops/Handler/PrettyPageHandler.php:232
```php
if (\Whoops\Util\Misc::canSendHeaders()) {
    header('Content-Type: text/html');
}
```

And Symfony is trying to put your header without replacing option while sending a response at
vendor/symfony/http-foundation/Response.php:339
```php
foreach ($this->headers->allPreserveCase() as $name => $values) {
    foreach ($values as $value) {
        header($name.': '.$value, false, $this->statusCode);
    }
}
```

The result:
```
FastCGI: comm with server "php7.0.8.fcgi" aborted: error parsing headers: duplicate header 'Content-type'
```

By the way, the tests have already been failed before the commit.