### PR TITLE
Exception info refactored into interface

### DIFF
--- a/src/Displayers/HtmlDisplayer.php
+++ b/src/Displayers/HtmlDisplayer.php
@@ -12,7 +12,7 @@
 namespace GrahamCampbell\Exceptions\Displayers;
 
 use Exception;
-use GrahamCampbell\Exceptions\ExceptionInfo;
+use GrahamCampbell\Exceptions\ExceptionInfoInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -25,7 +25,7 @@ class HtmlDisplayer implements DisplayerInterface
     /**
      * The exception info instance.
      *
-     * @var \GrahamCampbell\Exceptions\ExceptionInfo
+     * @var \GrahamCampbell\Exceptions\ExceptionInfoInterface
      */
     protected $info;
 
@@ -46,13 +46,13 @@ class HtmlDisplayer implements DisplayerInterface
     /**
      * Create a new html displayer instance.
      *
-     * @param \GrahamCampbell\Exceptions\ExceptionInfo $info
-     * @param callable                                 $assets
-     * @param string                                   $path
+     * @param \GrahamCampbell\Exceptions\ExceptionInfoInterface $info
+     * @param callable                                          $assets
+     * @param string                                            $path
      *
      * @return void
      */
-    public function __construct(ExceptionInfo $info, callable $assets, $path)
+    public function __construct(ExceptionInfoInterface $info, callable $assets, $path)
     {
         $this->info = $info;
         $this->assets = $assets;

--- a/src/Displayers/JsonDisplayer.php
+++ b/src/Displayers/JsonDisplayer.php
@@ -12,7 +12,7 @@
 namespace GrahamCampbell\Exceptions\Displayers;
 
 use Exception;
-use GrahamCampbell\Exceptions\ExceptionInfo;
+use GrahamCampbell\Exceptions\ExceptionInfoInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
@@ -25,18 +25,18 @@ class JsonDisplayer implements DisplayerInterface
     /**
      * The exception info instance.
      *
-     * @var \GrahamCampbell\Exceptions\ExceptionInfo
+     * @var \GrahamCampbell\Exceptions\ExceptionInfoInterface
      */
     protected $info;
 
     /**
      * Create a new json displayer instance.
      *
-     * @param \GrahamCampbell\Exceptions\ExceptionInfo $info
+     * @param \GrahamCampbell\Exceptions\ExceptionInfoInterface $info
      *
      * @return void
      */
-    public function __construct(ExceptionInfo $info)
+    public function __construct(ExceptionInfoInterface $info)
     {
         $this->info = $info;
     }

--- a/src/Displayers/ViewDisplayer.php
+++ b/src/Displayers/ViewDisplayer.php
@@ -12,7 +12,7 @@
 namespace GrahamCampbell\Exceptions\Displayers;
 
 use Exception;
-use GrahamCampbell\Exceptions\ExceptionInfo;
+use GrahamCampbell\Exceptions\ExceptionInfoInterface;
 use Illuminate\Contracts\View\Factory;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -26,7 +26,7 @@ class ViewDisplayer implements DisplayerInterface
     /**
      * The exception info instance.
      *
-     * @var \GrahamCampbell\Exceptions\ExceptionInfo
+     * @var \GrahamCampbell\Exceptions\ExceptionInfoInterface
      */
     protected $info;
 
@@ -40,12 +40,12 @@ class ViewDisplayer implements DisplayerInterface
     /**
      * Create a new view displayer instance.
      *
-     * @param \GrahamCampbell\Exceptions\ExceptionInfo $info
-     * @param \Illuminate\Contracts\View\Factory       $factory
+     * @param \GrahamCampbell\Exceptions\ExceptionInfoInterface $info
+     * @param \Illuminate\Contracts\View\Factory                $factory
      *
      * @return void
      */
-    public function __construct(ExceptionInfo $info, Factory $factory)
+    public function __construct(ExceptionInfoInterface $info, Factory $factory)
     {
         $this->info = $info;
         $this->factory = $factory;

--- a/src/ExceptionInfo.php
+++ b/src/ExceptionInfo.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
  *
  * @author Graham Campbell <graham@alt-three.com>
  */
-class ExceptionInfo
+class ExceptionInfo implements ExceptionInfoInterface
 {
     /**
      * The error info path.

--- a/src/ExceptionInfoInterface.php
+++ b/src/ExceptionInfoInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GrahamCampbell\Exceptions;
+
+use Exception;
+
+interface ExceptionInfoInterface
+{
+    /**
+     * Get the exception information.
+     *
+     * @param \Exception $exception
+     * @param string     $id
+     * @param int        $code
+     *
+     * @return array
+     */
+    public function generate(Exception $exception, $id, $code);
+}

--- a/src/ExceptionsServiceProvider.php
+++ b/src/ExceptionsServiceProvider.php
@@ -66,14 +66,14 @@ class ExceptionsServiceProvider extends ServiceProvider
             return new ExceptionIdentifier();
         });
 
-        $this->app->singleton(ExceptionInfo::class, function () {
+        $this->app->singleton(ExceptionInfoInterface::class, function () {
             $path = __DIR__.'/../resources/errors.json';
 
             return new ExceptionInfo(realpath($path));
         });
 
         $this->app->bind(HtmlDisplayer::class, function (Container $app) {
-            $info = $app->make(ExceptionInfo::class);
+            $info = $app->make(ExceptionInfoInterface::class);
             $generator = $app->make($this->app instanceof LumenApplication ? LumenGenerator::class : LaravelGenerator::class);
             $assets = function ($path) use ($generator) {
                 return $generator->asset($path);

--- a/tests/ExceptionHandlerTest.php
+++ b/tests/ExceptionHandlerTest.php
@@ -15,7 +15,7 @@ use Exception;
 use GrahamCampbell\Exceptions\Displayers\HtmlDisplayer;
 use GrahamCampbell\Exceptions\ExceptionHandler;
 use GrahamCampbell\Exceptions\ExceptionIdentifier;
-use GrahamCampbell\Exceptions\ExceptionInfo;
+use GrahamCampbell\Exceptions\ExceptionInfoInterface;
 use GrahamCampbell\Exceptions\NewExceptionHandler;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Container\Container;
@@ -182,7 +182,7 @@ class ExceptionHandlerTest extends AbstractTestCase
     public function testRenderException()
     {
         $this->app->bind(HtmlDisplayer::class, function (Container $app) {
-            $info = $app->make(ExceptionInfo::class);
+            $info = $app->make(ExceptionInfoInterface::class);
             $assets = function ($path) {
                 throw new RuntimeException('Oh no...');
             };
@@ -207,7 +207,7 @@ class ExceptionHandlerTest extends AbstractTestCase
     public function testRenderThrowable()
     {
         $this->app->bind(HtmlDisplayer::class, function (Container $app) {
-            $info = $app->make(ExceptionInfo::class);
+            $info = $app->make(ExceptionInfoInterface::class);
             $assets = function ($path) {
                 throw new TypeError('Foo.');
             };

--- a/tests/ExceptionInfoTest.php
+++ b/tests/ExceptionInfoTest.php
@@ -13,6 +13,7 @@ namespace GrahamCampbell\Tests\Exceptions;
 
 use Exception;
 use GrahamCampbell\Exceptions\ExceptionInfo;
+use GrahamCampbell\Exceptions\ExceptionInfoInterface;
 use InvalidArgumentException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\PreconditionFailedHttpException;
@@ -27,7 +28,7 @@ class ExceptionInfoTest extends AbstractTestCase
 {
     public function testExistingError()
     {
-        $info = $this->app->make(ExceptionInfo::class)->generate(new BadRequestHttpException('Made a mess.'), 'foo', 400);
+        $info = $this->app->make(ExceptionInfoInterface::class)->generate(new BadRequestHttpException('Made a mess.'), 'foo', 400);
 
         $expected = ['id' => 'foo', 'code' => 400, 'name' => 'Bad Request', 'detail' => 'Made a mess.', 'summary' => 'Made a mess.'];
 
@@ -36,7 +37,7 @@ class ExceptionInfoTest extends AbstractTestCase
 
     public function testShortError()
     {
-        $info = $this->app->make(ExceptionInfo::class)->generate(new PreconditionFailedHttpException(':('), 'bar', 412);
+        $info = $this->app->make(ExceptionInfoInterface::class)->generate(new PreconditionFailedHttpException(':('), 'bar', 412);
 
         $expected = ['id' => 'bar', 'code' => 412, 'name' => 'Precondition Failed', 'detail' => 'The server does not meet one of the preconditions that the requester put on the request.', 'summary' => 'Houston, We Have A Problem.'];
 
@@ -45,7 +46,7 @@ class ExceptionInfoTest extends AbstractTestCase
 
     public function testLongError()
     {
-        $info = $this->app->make(ExceptionInfo::class)->generate(new UnprocessableEntityHttpException('Made a mess a really really big mess this time. Everything has broken, and unicorns are crying.'), 'baz', 422);
+        $info = $this->app->make(ExceptionInfoInterface::class)->generate(new UnprocessableEntityHttpException('Made a mess a really really big mess this time. Everything has broken, and unicorns are crying.'), 'baz', 422);
 
         $expected = ['id' => 'baz', 'code' => 422, 'name' => 'Unprocessable Entity', 'detail' => 'Made a mess a really really big mess this time. Everything has broken, and unicorns are crying.', 'summary' => 'Houston, We Have A Problem.'];
 
@@ -54,7 +55,7 @@ class ExceptionInfoTest extends AbstractTestCase
 
     public function testBadError()
     {
-        $info = $this->app->make(ExceptionInfo::class)->generate(new Exception('Ooops.'), 'test', 666);
+        $info = $this->app->make(ExceptionInfoInterface::class)->generate(new Exception('Ooops.'), 'test', 666);
 
         $expected = ['id' => 'test', 'code' => 500, 'name' => 'Internal Server Error', 'detail' => 'An error has occurred and this resource cannot be displayed.', 'summary' => 'Houston, We Have A Problem.'];
 
@@ -63,7 +64,7 @@ class ExceptionInfoTest extends AbstractTestCase
 
     public function testHiddenError()
     {
-        $info = $this->app->make(ExceptionInfo::class)->generate(new InvalidArgumentException('Made another mess.'), 'hi', 503);
+        $info = $this->app->make(ExceptionInfoInterface::class)->generate(new InvalidArgumentException('Made another mess.'), 'hi', 503);
 
         $expected = ['id' => 'hi', 'code' => 503, 'name' => 'Service Unavailable', 'detail' => 'The server is currently unavailable. It may be overloaded or down for maintenance.', 'summary' => 'Houston, We Have A Problem.'];
 


### PR DESCRIPTION
I wanted to override the `ExceptionInfo` class with my own `generate()` method and don't need the `$path` as a constructor argument (I know it can be null, although maybe someone wants different constructor args). I figured `ExceptionInfo` should implement an `ExceptionInfoInterface` which would allow me to swap out for my own implementation

Tests updated & passing, manually tested in a laravel 5.4 app