### PR TITLE
Fix display custom error pages for various HTTP status

### DIFF
--- a/src/Displayers/ViewDisplayer.php
+++ b/src/Displayers/ViewDisplayer.php
@@ -67,7 +67,22 @@ class ViewDisplayer implements DisplayerInterface
     {
         $info = $this->info->generate($exception, $id, $code);
 
-        return new Response($this->factory->make("errors.{$code}", $info)->with(compact('exception')), $code, array_merge($headers, ['Content-Type' => $this->contentType()]));
+        return new Response($this->render($exception, $info), $code, array_merge($headers, ['Content-Type' => $this->contentType()]));
+    }
+
+    /**
+     * Render the page with given info and exception.
+     *
+     * @param \Exception $exception
+     * @param array      $info
+     *
+     * @return string
+     */
+    protected function render(Exception $exception, array $info)
+    {
+        $view = $this->factory->make("errors.{$code}", $info);
+
+        return $view->withException($exception)->render();
     }
 
     /**

--- a/src/Displayers/ViewDisplayer.php
+++ b/src/Displayers/ViewDisplayer.php
@@ -82,7 +82,7 @@ class ViewDisplayer implements DisplayerInterface
     {
         $view = $this->factory->make("errors.{$code}", $info);
 
-        return $view->withException($exception)->render();
+        return $view->with('exception', $exception)->render();
     }
 
     /**

--- a/src/Displayers/ViewDisplayer.php
+++ b/src/Displayers/ViewDisplayer.php
@@ -67,7 +67,7 @@ class ViewDisplayer implements DisplayerInterface
     {
         $info = $this->info->generate($exception, $id, $code);
 
-        return new Response($this->factory->make("errors.{$code}", $info), $code, array_merge($headers, ['Content-Type' => $this->contentType()]));
+        return new Response($this->factory->make("errors.{$code}", $info)->with(compact('exception')), $code, array_merge($headers, ['Content-Type' => $this->contentType()]));
     }
 
     /**

--- a/src/Displayers/ViewDisplayer.php
+++ b/src/Displayers/ViewDisplayer.php
@@ -67,7 +67,7 @@ class ViewDisplayer implements DisplayerInterface
     {
         $info = $this->info->generate($exception, $id, $code);
 
-        return new Response($this->render($exception, $info), $code, array_merge($headers, ['Content-Type' => $this->contentType()]));
+        return new Response($this->render($exception, $info, $code), $code, array_merge($headers, ['Content-Type' => $this->contentType()]));
     }
 
     /**
@@ -75,10 +75,11 @@ class ViewDisplayer implements DisplayerInterface
      *
      * @param \Exception $exception
      * @param array      $info
+     * @param int        $code
      *
      * @return string
      */
-    protected function render(Exception $exception, array $info)
+    protected function render(Exception $exception, array $info, int $code)
     {
         $view = $this->factory->make("errors.{$code}", $info);
 

--- a/tests/Displayers/ViewDisplayerTest.php
+++ b/tests/Displayers/ViewDisplayerTest.php
@@ -18,6 +18,7 @@ use GrahamCampbell\Exceptions\Displayers\ViewDisplayer;
 use GrahamCampbell\Exceptions\ExceptionInfo;
 use GrahamCampbell\Tests\Exceptions\AbstractTestCase;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
 use Mockery;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
@@ -30,10 +31,14 @@ class ViewDisplayerTest extends AbstractTestCase
 {
     public function testError()
     {
-        $displayer = new ViewDisplayer(new ExceptionInfo(__DIR__.'/../../resources/errors.json'), $factory = Mockery::mock(Factory::class));
+        $view = Mockery::mock(View::class);
+        $view->shouldReceive('with')->once();
+        $view->shouldReceive('render')->once()->andReturn("Gutted.\n");
 
-        $factory->shouldReceive('make')->once()->with('errors.502', ['id' => 'foo', 'code' => 502, 'name' => 'Bad Gateway', 'detail' => 'Oh noes!', 'summary' => 'Oh noes!'])->andReturn("Gutted.\n");
+        $factory = Mockery::mock(Factory::class);
+        $factory->shouldReceive('make')->once()->with('errors.502', ['id' => 'foo', 'code' => 502, 'name' => 'Bad Gateway', 'detail' => 'Oh noes!', 'summary' => 'Oh noes!'])->andReturn($view);
 
+        $displayer = new ViewDisplayer(new ExceptionInfo(__DIR__.'/../../resources/errors.json'), $factory);
         $response = $displayer->display(new HttpException(502, 'Oh noes!'), 'foo', 502, []);
 
         $this->assertSame("Gutted.\n", $response->getContent());

--- a/tests/Displayers/ViewDisplayerTest.php
+++ b/tests/Displayers/ViewDisplayerTest.php
@@ -32,7 +32,7 @@ class ViewDisplayerTest extends AbstractTestCase
     public function testError()
     {
         $view = Mockery::mock(View::class);
-        $view->shouldReceive('with')->once();
+        $view->shouldReceive('with')->once()->andReturn($view);
         $view->shouldReceive('render')->once()->andReturn("Gutted.\n");
 
         $factory = Mockery::mock(Factory::class);


### PR DESCRIPTION
The variable `$exception` was not passed to the `view()`:

`<h2>{{ $exception->getMessage() }}</h2>` now working :-)

[Docs here](https://laravel.com/docs/errors#http-exceptions)