### PR TITLE
Check for null

### DIFF
--- a/src/ExceptionIdentifier.php
+++ b/src/ExceptionIdentifier.php
@@ -50,7 +50,7 @@ class ExceptionIdentifier
         }
 
         // cleanup in preparation for the identification
-        if (count($this->identification) >= 16) {
+        if (null !== $this->identification && count($this->identification) >= 16) {
             array_shift($this->identification);
         }
 


### PR DESCRIPTION
checking null to prevent "Parameter must be an array or an object that implements Countable" error in php v7.2+