### PR TITLE
[9.4] Fix display custom error pages for various HTTP status

### DIFF
--- a/src/Displayers/ViewDisplayer.php
+++ b/src/Displayers/ViewDisplayer.php
@@ -65,7 +65,23 @@ class ViewDisplayer implements DisplayerInterface
     {
         $info = $this->info->generate($exception, $id, $code);
 
-        return new Response($this->factory->make("errors.{$code}", $info), $code, array_merge($headers, ['Content-Type' => $this->contentType()]));
+        return new Response($this->render($exception, $info, $code), $code, array_merge($headers, ['Content-Type' => $this->contentType()]));
+    }
+
+    /**
+     * Render the page with given info and exception.
+     *
+     * @param \Exception $exception
+     * @param array      $info
+     * @param int        $code
+     *
+     * @return string
+     */
+    protected function render(Exception $exception, array $info, $code)
+    {
+        $view = $this->factory->make("errors.{$code}", $info);
+
+        return $view->with('exception', $exception)->render();
     }
 
     /**

--- a/tests/Displayers/ViewDisplayerTest.php
+++ b/tests/Displayers/ViewDisplayerTest.php
@@ -16,6 +16,7 @@ use GrahamCampbell\Exceptions\Displayers\ViewDisplayer;
 use GrahamCampbell\Exceptions\ExceptionInfo;
 use GrahamCampbell\Tests\Exceptions\AbstractTestCase;
 use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
 use Mockery;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
@@ -28,12 +29,16 @@ class ViewDisplayerTest extends AbstractTestCase
 {
     public function testError()
     {
-        $displayer = new ViewDisplayer(new ExceptionInfo(__DIR__.'/../../resources/errors.json'), $factory = Mockery::mock(Factory::class));
+        $view = Mockery::mock(View::class);
+        $view->shouldReceive('with')->once()->andReturn($view);
+        $view->shouldReceive('render')->once()->andReturn("Gutted.\n");
 
-        $factory->shouldReceive('make')->once()->with('errors.502', ['id' => 'foo', 'code' => 502, 'name' => 'Bad Gateway', 'detail' => 'Oh noes!', 'summary' => 'Oh noes!'])->andReturn("Gutted.\n");
+        $factory = Mockery::mock(Factory::class);
+        $factory->shouldReceive('make')->once()->with('errors.502', ['id' => 'foo', 'code' => 502, 'name' => 'Bad Gateway', 'detail' => 'Oh noes!', 'summary' => 'Oh noes!'])->andReturn($view);
 
+        $displayer = new ViewDisplayer(new ExceptionInfo(__DIR__.'/../../resources/errors.json'), $factory);
         $response = $displayer->display(new HttpException(502, 'Oh noes!'), 'foo', 502, []);
-
+        
         $this->assertSame("Gutted.\n", $response->getContent());
         $this->assertSame(502, $response->getStatusCode());
         $this->assertSame('text/html', $response->headers->get('Content-Type'));


### PR DESCRIPTION
#124 [9.4] Fix display custom error pages for various HTTP status