### PR TITLE
Check to see if a variable is countable

### DIFF
--- a/src/ExceptionIdentifier.php
+++ b/src/ExceptionIdentifier.php
@@ -50,7 +50,7 @@ class ExceptionIdentifier
         }
 
         // cleanup in preparation for the identification
-        if ($this->is_countable(count($this->identification)) >= 16) {
+        if ($this->isCountable($this->identification) && count($this->identification) >= 16) {
             array_shift($this->identification);
         }
 
@@ -82,13 +82,8 @@ class ExceptionIdentifier
         return vsprintf('%08s-%04s-%04s-%02s%02s-%012s', $params);
     }
 
-    /**
-     * Checks to see if a variable is countable (for PHP 7.2 compatability)
-     * @param  mixed  $var
-     * @return boolean
-     */
-    public function is_countable($var)
+    public function isCountable($var)
     {
-        return is_array($var) || $var instanceof Countable;
+        return is_array($var) || $var instanceof \Countable;
     }
 }

--- a/src/ExceptionIdentifier.php
+++ b/src/ExceptionIdentifier.php
@@ -50,7 +50,7 @@ class ExceptionIdentifier
         }
 
         // cleanup in preparation for the identification
-        if (count($this->identification) >= 16) {
+        if ($this->is_countable(count($this->identification)) >= 16) {
             array_shift($this->identification);
         }
 
@@ -80,5 +80,15 @@ class ExceptionIdentifier
         $params = [substr($hash, 0, 8), substr($hash, 8, 4), sprintf('%04x', $timeHi), sprintf('%02x', $clockSeqHi), substr($hash, 18, 2), substr($hash, 20, 12)];
 
         return vsprintf('%08s-%04s-%04s-%02s%02s-%012s', $params);
+    }
+
+    /**
+     * Checks to see if a variable is countable (for PHP 7.2 compatability)
+     * @param  mixed  $var
+     * @return boolean
+     */
+    public function is_countable($var)
+    {
+        return is_array($var) || $var instanceof Countable;
     }
 }


### PR DESCRIPTION
As of PHP 7.2, when a variable is passed to `count()` that is not Countable, it will give an E_WARNING. Per the documentation

> Environments that display warnings or convert them to more severe errors/exceptions would be affected, but this should just bring attention to a bug in the code.

I've implemented a method that checks if the variable is countable by checking if it is an array, or if it is an instance of Countable.