### PR TITLE
[11.0] Displayer should use exact Content-Type

### DIFF
--- a/src/Displayers/DebugDisplayer.php
+++ b/src/Displayers/DebugDisplayer.php
@@ -39,7 +39,7 @@ class DebugDisplayer implements DisplayerInterface
     {
         $content = $this->whoops()->handleException($exception);
 
-        return new Response($content, $code, array_merge($headers, ['Content-Type' => 'text/html']));
+        return new Response($content, $code, array_merge($headers, ['Content-Type' => $this->contentType()]));
     }
 
     /**


### PR DESCRIPTION
The DebugDisplayer should use the it's supported Content-Type to render a response that is associated with a specified exception.

This is just a small and simple pull request. Please view the change for more details.

Thank you for reviewing!