### PR TITLE
don't pass identifier to displayers if exception shouldnt report

### DIFF
--- a/resources/error.html
+++ b/resources/error.html
@@ -58,8 +58,7 @@
                 work hard to get this resolved as soon as possible.
             </p>
             <p>
-                This error can be identified by <i>{{ $id }}</i>.
-                You might want to take a note of this code.
+                {{ $identification }}
             </p>
             <p>
                 Perhaps you would like to go to our <a href="{{ $home_url }}">home page</a>?

--- a/src/Displayer/AbstractJsonDisplayer.php
+++ b/src/Displayer/AbstractJsonDisplayer.php
@@ -59,7 +59,7 @@ abstract class AbstractJsonDisplayer implements DisplayerInterface
     {
         $info = $this->info->generate($exception, $id, $code);
 
-        $error = ['id' => $id, 'status' => $info['code'], 'title' => $info['name'], 'detail' => $info['detail']];
+        $error = array_filter(['id' => $id, 'status' => $info['code'], 'title' => $info['name'], 'detail' => $info['detail']]);
 
         return new JsonResponse(['errors' => [$error]], $code, array_merge($headers, ['Content-Type' => $this->contentType()]));
     }

--- a/src/Displayer/HtmlDisplayer.php
+++ b/src/Displayer/HtmlDisplayer.php
@@ -93,9 +93,19 @@ final class HtmlDisplayer implements DisplayerInterface
         $info['home_url'] = $generator('/');
         $info['favicon_url'] = $generator('favicon.ico');
 
+        if ($info['id']) {
+            $info['identification'] = "This error can be identified by <i>{$info['id']}</i>. You might want to take a note of this code.";
+        } else {
+            $info['identification'] = '';
+        }
+
         foreach ($info as $key => $val) {
             $content = str_replace("{{ $$key }}", (string) $val, (string) $content);
         }
+
+        $content = str_replace('            <p>
+                
+            </p>', '', $content);
 
         return $content;
     }

--- a/src/Displayer/HtmlDisplayer.php
+++ b/src/Displayer/HtmlDisplayer.php
@@ -94,7 +94,8 @@ final class HtmlDisplayer implements DisplayerInterface
         $info['favicon_url'] = $generator('favicon.ico');
 
         if ($info['id']) {
-            $info['identification'] = "This error can be identified by <i>{$info['id']}</i>. You might want to take a note of this code.";
+            $info['identification'] = "This error can be identified by <i>{$info['id']}</i>.
+                You might want to take a note of this code.";
         } else {
             $info['identification'] = '';
         }

--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -231,7 +231,11 @@ class ExceptionHandler implements HandlerInterface
      */
     protected function getResponse(Request $request, Throwable $exception, Throwable $transformed)
     {
-        $id = $this->container->make(IdentifierInterface::class)->identify($exception);
+        if ($this->shouldReport($exception) ) {
+            $id = $this->container->make(IdentifierInterface::class)->identify($exception);
+        } else {
+            $id = '';
+        }
 
         $flattened = FlattenException::createFromThrowable($transformed);
         $code = $flattened->getStatusCode();

--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -231,7 +231,7 @@ class ExceptionHandler implements HandlerInterface
      */
     protected function getResponse(Request $request, Throwable $exception, Throwable $transformed)
     {
-        if ($this->shouldReport($exception) ) {
+        if ($this->shouldReport($exception)) {
             $id = $this->container->make(IdentifierInterface::class)->identify($exception);
         } else {
             $id = '';


### PR DESCRIPTION
Hi! Case:

1) Add some exception to `\GrahamCampbell\Exceptions\ExceptionHandler::$dontReport` array.

2) Throw that exception.

3) `\GrahamCampbell\Exceptions\ExceptionHandler::report` check `\GrahamCampbell\Exceptions\ExceptionHandler::shouldntReport` and skip logging exception and its identifier.

4) `\GrahamCampbell\Exceptions\ExceptionHandler::getResponse` don't check `\GrahamCampbell\Exceptions\ExceptionHandler::shouldntReport` and render identifier to response.

5) User see error page with identifier and send message to me with that identifier.

6) I trying to find this identifier in my log storage and I can't find it. I am nervous and do not understand what happened. I'm wasting my time.

7) Then I understand that there are exceptions that are not logged.

My fix is to check the exception via `\GrahamCampbell\Exceptions\ExceptionHandler::shouldReport` before rendering and not pass the identifier if the exception was not logged.

And some fixes in displayers for don't show an empty identifier.