### PR TITLE
Remove app from getServiceProviderClass definition

### DIFF
--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -26,11 +26,9 @@ abstract class AbstractTestCase extends AbstractPackageTestCase
     /**
      * Get the service provider class.
      *
-     * @param \Illuminate\Contracts\Foundation\Application $app
-     *
      * @return string
      */
-    protected function getServiceProviderClass($app)
+    protected function getServiceProviderClass()
     {
         return ExceptionsServiceProvider::class;
     }


### PR DESCRIPTION
for fix

```
PHP Warning:  Declaration of GrahamCampbell\Tests\Exceptions\AbstractTestCase::getServiceProviderClass($app) should be compatible with GrahamCampbell\TestBench\AbstractPackageTestCase::getServiceProviderClass() in /home/albus/projects/Laravel-Exceptions/tests/AbstractTestCase.php on line 33
PHP Fatal error:  Declaration of GrahamCampbell\Tests\Exceptions\AbstractTestCase::getServiceProviderClass($app) must be compatible with GrahamCampbell\TestBenchCore\ServiceProviderTrait::getServiceProviderClass() in /home/albus/projects/Laravel-Exceptions/tests/ServiceProviderTest.php on line 33
```

see https://github.com/GrahamCampbell/Laravel-TestBench/commit/f27ca205aa55daf00fa67e53cbc9f48742b443c0#diff-73e37cfe391affa626353ac77c2752d0eb6dd1fb2c7e131a0b02871f7561b4b0